### PR TITLE
fixed lint warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Limited Action Bar title to a single line with ellipsis to comply with Material Design 2 guidelines for standard app bars.
+- Fix compiler warnings
 
 ## [1.9] - 2024-05-04
 

--- a/app/src/main/java/com/hotmail/or_dvir/sabinesList/preferences/ThemePreference.kt
+++ b/app/src/main/java/com/hotmail/or_dvir/sabinesList/preferences/ThemePreference.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class ThemePreference(@StringRes val labelRes: Int) {
+enum class ThemePreference(@param: StringRes val labelRes: Int) {
     @SerialName("light")
     LIGHT(R.string.preferenceScreen_theme_light),
 

--- a/app/src/main/java/com/hotmail/or_dvir/sabinesList/ui/BaseScreenModel.kt
+++ b/app/src/main/java/com/hotmail/or_dvir/sabinesList/ui/BaseScreenModel.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.launch
 
 abstract class BaseScreenModel : ScreenModel {
 
-    //since we are observing the DB directly, we dont have the "prompt" to start the loading state.
+    //since we are observing the DB directly, we don't have the "prompt" to start the loading state.
     //so instead we initialize to true and set to false when we get our first result
     private var _isLoading = MutableStateFlow(true)
     var isLoading = _isLoading.asStateFlow()
@@ -42,7 +42,7 @@ abstract class BaseScreenModel : ScreenModel {
     }
 
     sealed class SideEffect {
-        data class ShowMessage(@StringRes val messageRes: Int) : SideEffect()
+        data class ShowMessage(@param: StringRes val messageRes: Int) : SideEffect()
     }
 
     interface UserEvent {

--- a/app/src/main/java/com/hotmail/or_dvir/sabinesList/ui/MenuItemUiState.kt
+++ b/app/src/main/java/com/hotmail/or_dvir/sabinesList/ui/MenuItemUiState.kt
@@ -7,8 +7,8 @@ import com.hotmail.or_dvir.sabinesList.R
 internal typealias OnMenuItemClicked = (item: MenuItemUiState) -> Unit
 
 sealed class MenuItemUiState(
-    @DrawableRes val iconRes: Int,
-    @StringRes val label: Int,
+    @param: DrawableRes val iconRes: Int,
+    @param: StringRes val label: Int,
     val isEnabled: Boolean = true
 ) {
     data class Search(val enabled: Boolean = true) :

--- a/app/src/main/java/com/hotmail/or_dvir/sabinesList/ui/listItemsScreen/BottomNavigationListItem.kt
+++ b/app/src/main/java/com/hotmail/or_dvir/sabinesList/ui/listItemsScreen/BottomNavigationListItem.kt
@@ -5,9 +5,9 @@ import androidx.annotation.StringRes
 import com.hotmail.or_dvir.sabinesList.R
 
 sealed class BottomNavigationListItem(
-    @StringRes val textRes: Int,
-    @StringRes val contentDescriptionRes: Int,
-    @DrawableRes val iconRes: Int
+    @param: StringRes val textRes: Int,
+    @param: StringRes val contentDescriptionRes: Int,
+    @param: DrawableRes val iconRes: Int
 ) {
     object AllItems : BottomNavigationListItem(
         textRes = R.string.bottomNavigation_all,

--- a/backlog/Maintenance.md
+++ b/backlog/Maintenance.md
@@ -6,8 +6,3 @@ This file tracks general code maintenance tasks.
 
 ### [TASK-001] 
 *   **Description**: go over visibility of all functions/classes. surely they shouldn't all be `public`.
-
-### [TASK-002]
-*   **Description**: i have multiple warnings throughout the project about annotations like
-`@StringRes` and `@drawableRes` (but not only) which say 
-"This annotation is currently applied to the value parameter only, but in the future it will also be applied to field." 


### PR DESCRIPTION
*   **Description**: i have multiple warnings throughout the project about annotations like
`@StringRes` and `@drawableRes` (but not only) which say 
"This annotation is currently applied to the value parameter only, but in the future it will also be applied to field." 